### PR TITLE
Clarify likelihood free parameters

### DIFF
--- a/lya_likelihood/py/likelihood.py
+++ b/lya_likelihood/py/likelihood.py
@@ -156,7 +156,7 @@ class Likelihood(object):
         for par in self.free_params:
             param_list.append(par.name)
 
-        return
+        return param_list
 
 
     def default_sampling_point(self):

--- a/lya_likelihood/py/likelihood.py
+++ b/lya_likelihood/py/likelihood.py
@@ -47,20 +47,16 @@ class Likelihood(object):
 
         # (optionally) get rid of low-k data points
         self.data._cull_data(kmin_kms)
-        # list of parameter names, order might be different than get_parameters
-        self.free_parameters=free_parameters
-        # list of tuples with limits, same order than above
-        self.free_param_limits=free_param_limits
 
         if theory:
             self.theory=theory
         else:
             ## Use the free_param_names to determine whether to use
             ## a LyaTheory or FullTheory object
-            compressed=bool(set(self.free_parameters) & set(["Delta2_star",
+            compressed=bool(set(free_parameters) & set(["Delta2_star",
                                 "n_star","alpha_star","f_star","g_star"]))
 
-            full=bool(set(self.free_parameters) & set(["H0","mnu","As","ns"]))
+            full=bool(set(free_parameters) & set(["H0","mnu","As","ns"]))
 
             if self.verbose:
                 if compressed:
@@ -68,7 +64,7 @@ class Likelihood(object):
                 elif full:
                     print('using full theory')
                 else:
-                    print('not varying cosmo params',self.free_parameters)
+                    print('not varying cosmo params',free_parameters)
 
             assert (compressed and full)==False, "Cannot vary both compressed and full likelihood parameters"
 
@@ -101,7 +97,7 @@ class Likelihood(object):
                     print("No cosmology parameters are varied")
 
         # setup parameters
-        self.set_free_parameters(free_parameters,self.free_param_limits)
+        self.set_free_parameters(free_parameters,free_param_limits)
 
         if self.verbose: print(len(self.free_params),'free parameters')
 
@@ -128,15 +124,18 @@ class Likelihood(object):
         # get all parameters in theory, free or not
         params = self.theory.get_parameters()
 
-        # select parameters using input list of names
-        for par in params:
-            if par.name in free_parameter_names:
-                if free_param_limits is not None:
-                    ## Set min and max of each parameter if
-                    ## a list is given. otherwise leave as default
-                    par.min_value=free_param_limits[self.free_parameters.index(par.name)][0]
-                    par.max_value=free_param_limits[self.free_parameters.index(par.name)][1]
-                self.free_params.append(par)
+        ## select free parameters, make sure ordering
+        ## in self.free_params is same as
+        ## in self.free_parameters
+        for par_name in free_parameter_names:
+            for par in params:
+                if par.name == par_name:
+                    if free_param_limits is not None:
+                        ## Set min and max of each parameter if
+                        ## a list is given. otherwise leave as default
+                        par.min_value=free_param_limits[free_parameter_names.index(par.name)][0]
+                        par.max_value=free_param_limits[free_parameter_names.index(par.name)][1]
+                    self.free_params.append(par)
 
         Nfree=len(self.free_params)
         Nin=len(free_parameter_names)
@@ -145,6 +144,17 @@ class Likelihood(object):
 
         if self.verbose:
             print('likelihood setup with {} free parameters'.format(Nfree))
+
+        return
+
+
+    def get_free_parameter_list(self):
+        """ Return a list of the names of all free parameters
+        for this object """
+
+        param_list=[]
+        for par in self.free_params:
+            param_list.append(par.name)
 
         return
 

--- a/lya_sampler/py/emcee_sampler.py
+++ b/lya_sampler/py/emcee_sampler.py
@@ -55,8 +55,6 @@ class EmceeSampler(object):
             if like:
                 if self.verbose: print('use input likelihood')
                 self.like=like
-                if free_parameters:
-                    self.like.set_free_parameters(free_parameters,like.free_param_limits)
             else:
                 if self.verbose: print('use default likelihood')
                 data=data_PD2013.P1D_PD2013(blind_data=True)
@@ -492,10 +490,14 @@ class EmceeSampler(object):
         saveDict["data_year"]=self.like.data.data_year
 
         free_params_save=[]
+        free_param_limits=[]
         for par in self.like.free_params:
+            ## This parameter limits are saved twice but for the sake
+            ## of backwards compatibility I'm going to leave this
             free_params_save.append([par.name,par.min_value,par.max_value])
+            free_param_limits.append([par.min_value,par.max_value])
         saveDict["free_params"]=free_params_save
-        saveDict["free_param_limits"]=self.like.free_param_limits
+        saveDict["free_param_limits"]=free_param_limits
 
         ## Sampler stuff
         saveDict["burn_in"]=self.burnin_nsteps

--- a/lya_sampler/py/emcee_sampler.py
+++ b/lya_sampler/py/emcee_sampler.py
@@ -290,7 +290,7 @@ class EmceeSampler(object):
         
         plt.figure()
 
-        n = 100 * np.arange(self.burnin_nsteps, len(self.autocorr)+1)
+        n = 100 * np.arange(1, len(self.autocorr)+1)
         plt.plot(n, n / 100.0, "--k")
         plt.plot(n, self.autocorr)
         plt.xlim(0, n.max())

--- a/lya_sampler/py/emcee_sampler.py
+++ b/lya_sampler/py/emcee_sampler.py
@@ -492,7 +492,7 @@ class EmceeSampler(object):
         free_params_save=[]
         free_param_limits=[]
         for par in self.like.free_params:
-            ## This parameter limits are saved twice but for the sake
+            ## The parameter limits are saved twice but for the sake
             ## of backwards compatibility I'm going to leave this
             free_params_save.append([par.name,par.min_value,par.max_value])
             free_param_limits.append([par.min_value,par.max_value])

--- a/lya_sampler/py/emcee_sampler.py
+++ b/lya_sampler/py/emcee_sampler.py
@@ -113,8 +113,8 @@ class EmceeSampler(object):
         ## Set up list of parameter names in tex format for plotting
         self.paramstrings=[]
         self.truth=[] ## Truth value for chainconsumer plots
-        for param in self.like.free_parameters:
-            self.paramstrings.append(self.param_dict[param])
+        for param in self.like.free_params:
+            self.paramstrings.append(self.param_dict[param.name])
         for param in self.like.free_params:
             self.truth.append(param.value)
 
@@ -383,10 +383,8 @@ class EmceeSampler(object):
         if self.verbose: print("Setting up likelihood")
         ## Set up likelihood
         free_param_list=[]
-        limits_list=[]
         for item in config["free_params"]:
             free_param_list.append(item[0])
-            limits_list.append([item[1],item[2]])
 
         ## Not all saved chains will have this flag
         try:


### PR DESCRIPTION
Related to issue #60 , removed `like.free_parameters` and `like.free_parameter_limits`, replaced with a method to return the list of free parameters, although I don't think this is currently used anywhere in the code. There might  be a notebook where it is.