### PR TITLE
Do not use test simulation cosmology as fiducial by default. Extract …

### DIFF
--- a/lya_likelihood/py/likelihood.py
+++ b/lya_likelihood/py/likelihood.py
@@ -22,7 +22,7 @@ class Likelihood(object):
                     verbose=False,
                     prior_Gauss_rms=0.2,
                     kmin_kms=None,emu_cov_factor=1,
-                    use_sim_cosmo=True):
+                    use_sim_cosmo=False):
         """Setup likelihood from theory and data. Options:
             - free_param_names is a list of param names, in any order
             - free_param_limits list of tuples, same order than free_param_names


### PR DESCRIPTION
…the truth from the test simulation as a method in the sampler object instead.

For the compressed likelihood tests we shouldn't see any difference in posteriors here. We should now recover the wrong value of A_s from the 0.3eV massive neutrino simulation when sampling primordial power. Will run this test before merging to make sure we understand what's going on.