### PR TITLE
Sampler updates - asymmetric kernel and emulator hyperparameters

### DIFF
--- a/lya_sampler/py/emcee_sampler.py
+++ b/lya_sampler/py/emcee_sampler.py
@@ -533,10 +533,24 @@ class EmceeSampler(object):
         self._write_dict_to_text(saveDict)
 
         ## Save plots
-        self.plot_best_fit()
-        self.plot_prediction()
-        self.plot_autocorrelation_time()
-        self.plot_corner()
+        ## Using try as have latex issues when running on compute
+        ## nodes on some clusters
+        try:
+            self.plot_best_fit()
+        except:
+            print("Can't plot best fit")
+        try:
+            self.plot_prediction()
+        except:
+            print("Can't plot prediction")
+        try:
+            self.plot_autocorrelation_time()
+        except:
+            print("Can't plot autocorrelation time")
+        try:
+            self.plot_corner()
+        except:
+            print("Can't plot corner")
 
         return
 

--- a/lya_sampler/py/emcee_sampler.py
+++ b/lya_sampler/py/emcee_sampler.py
@@ -654,10 +654,13 @@ cosmo_params=["Delta2_star","n_star","alpha_star",
                 "H0","mnu","As","ns","ombh2","omch2"]
 
 
-def compare_corners(chain_files,labels,save_string=None):
+def compare_corners(chain_files,labels,plot_params=None,save_string=None):
     """ Function to take a list of chain files and overplot the chains
     Pass a list of chain files (ints) and a list of labels (strings)
-     - save_string must include file extension (i.e. .pdf, .png etc)"""
+     - plot_params: list of parameters (in code variables, not latex form)
+                    to plot if only a subset is desired
+     - save_string: to save the plot. Must include
+                    file extension (i.e. .pdf, .png etc) """
     
     assert len(chain_files)==len(labels)
     
@@ -677,7 +680,16 @@ def compare_corners(chain_files,labels,save_string=None):
     
     c.configure(diagonal_tick_labels=False, tick_font_size=10,
                 label_font_size=25, max_ticks=4)
-    fig = c.plotter.plot(figsize=(15,15),truth=truth_dict)
+    if plot_params==None:
+        fig = c.plotter.plot(figsize=(15,15),truth=truth_dict)
+    else:
+        ## From plot_param list, build list of parameter
+        ## strings to plot
+        plot_param_strings=[]
+        for par in plot_params:
+            plot_param_strings.append(param_dict[par])
+        fig = c.plotter.plot(figsize=(15,15),
+                parameters=plot_param_strings,truth=truth_dict)
     if save_string:
         fig.savefig("%s" % save_string)
     fig.show()

--- a/lya_sampler/scripts/example.config
+++ b/lya_sampler/scripts/example.config
@@ -10,6 +10,7 @@ drop_temp_rescalings=True
 nearest_tau=True
 undersample_cube=1
 z_emulator=False
+asym_kernel=True
 free_parameters=[Delta2_star,n_star,ln_tau_0,ln_tau_1,ln_sigT_kms_0,ln_sigT_kms_1,ln_gamma_0,ln_gamma_1,ln_kF_0,ln_kF_1]
 nwalkers=25
 burn_in=2000

--- a/lya_sampler/scripts/multiprocess_sampler.py
+++ b/lya_sampler/scripts/multiprocess_sampler.py
@@ -29,6 +29,7 @@ parser.add_argument('--z_max',type=float, help='Maximum redshift')
 parser.add_argument('--drop_tau_rescalings',action='store_true', help='Drop mean flux rescalings')
 parser.add_argument('--drop_temp_rescalings',action='store_true', help='Drop temperature rescalings')
 parser.add_argument('--nearest_tau', action='store_true',help='Keep only nearest tau rescaling? Only used when tau rescalings are included')
+parser.add_argument('--asym_kernel', action='store_true',help='Use asymmetric, rbf-only kernel for the GP')
 parser.add_argument('--undersample_cube',type=int, help='Undersample the Latin hypercube of training sims')
 parser.add_argument('--z_emulator',action='store_true',help='Whether or not to use a single GP on each redshfit bin')
 parser.add_argument('--free_parameters', nargs="+", help='List of parameters to sample')
@@ -99,15 +100,15 @@ archive=p1d_arxiv.ArxivP1D(basedir=args.basedir,
 if args.z_emulator==False:
     emu=gp_emulator.GPEmulator(args.basedir,p1d_label,skewers_label,z_max=args.z_max,
                                     passArxiv=archive,
-                                    verbose=False,paramList=paramList,train=False,
+                                    verbose=False,paramList=paramList,train=True,
                                     emu_type=args.emu_type, checkHulls=False,kmax_Mpc=kmax_Mpc,
+                                    asymmetric_kernel=args.asym_kernel,rbf_only=args.asym_kernel,
                                     drop_tau_rescalings=args.drop_tau_rescalings,
                                     drop_temp_rescalings=args.drop_temp_rescalings,
 				                    set_noise_var=args.emu_noise_var)
-    emu.load_default()
 else:
     emu=z_emulator.ZEmulator(args.basedir,p1d_label,skewers_label,z_max=args.z_max,
-                                    verbose=False,paramList=paramList,train=False,
+                                    verbose=False,paramList=paramList,train=True,
                                     emu_type=args.emu_type,passArxiv=archive,checkHulls=False,
                                     kmax_Mpc=kmax_Mpc,
                                     drop_tau_rescalings=args.drop_tau_rescalings,

--- a/lya_sampler/scripts/multiprocess_sampler.py
+++ b/lya_sampler/scripts/multiprocess_sampler.py
@@ -57,16 +57,21 @@ print("----------")
 ## configargparse cannot accept nested lists or dictionaries
 ## so no elegant solution to passing a prior volume right now
 ## these are still saved with the sampler so no book-keeping issues though
+
+## for reference, the default primordial limits I have been using are
+## [['As', 1.5e-09, 3.5e-09], ['ns', 0.88, 0.99]
+## And for compressed params,
+## [["Delta2_star", 0.24, 0.47], ["n_star", -2.352, -2.25]]
 free_param_limits=[[0.24, 0.47],
                     [-2.352, -2.25],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2],
-                    [-0.2, 0.2]]
+                    [-0.4, 0.4],
+                    [-0.4, 0.4],
+                    [-0.4, 0.4],
+                    [-0.4, 0.4],
+                    [-0.4, 0.4],
+                    [-0.4, 0.4],
+                    [-0.4, 0.4],
+                    [-0.4, 0.4]]
 
 skewers_label=args.skewers_label
 p1d_label=None
@@ -146,4 +151,11 @@ multi_time = end - start
 print("Sampling took {0:.1f} seconds".format(multi_time))
 
 sampler.write_chain_to_file()
+
+## Copy corresponding job files to save folder
+jobstring=jobstring="job"+os.environ['SLURM_JOBID']+".out"
+slurmstring="slurm-"+os.environ['SLURM_JOBID']+".out"
+shutil.copy(jobstring,sampler.save_directory+"/"+jobstring)
+shutil.copy(slurmstring,sampler.save_directory+"/"+slurmstring)
+
 


### PR DESCRIPTION
The primary changes in this PR will be:
1. Add an option to the sampler config file to use an asymmetric, rbf only kernel
2. Change the way emulator hyperparameters are dealt with when setting up samplers. Currently we load a set of saved hyperparameters that were optimised on the 30 simulation suite and use these by default. The primary reason for this was that we wanted to fix hyperparameters when running with tau rescalings, as re-optimising caused all kinds of problems with the emulator performance. Given we are not going to be looking at tau rescalings for now, but instead running with an asymmetric kernel, and given that the optimisation time is on the order of 10 seconds, I think we can change our default approach to just optimising new hyperparameters on whatever training set the emulator is set up with. This is also a more consistent approach, since we are no longer mixing different hyperparameters and training sets, even though I have shown that the difference here is minimal.

There is also a small change to the sampler plotting scripts that allows for a subsample of parameters to be plot on a corner plot.