### PR TITLE
get_p1d_Mpc() only returns one k bin now

### DIFF
--- a/p1d_emulator/py/test_simulation.py
+++ b/p1d_emulator/py/test_simulation.py
@@ -154,10 +154,8 @@ class TestSimulation(object):
             emu_dict["alpha_p"]=linP_values[len(zs)-aa-1]["alpha_p"]
             emu_dict["f_p"]=linP_values[len(zs)-aa-1]["f_p"]
             self.emu_calls.append(emu_dict)
-            
-        # Not all redshifts will have the same number of wavenumbers, because
-        # of annoying numerical errors
-        # self.k_Mpc=self.k_Mpc[0] ## Discard other k bins, they are the same
+
+        self.k_Mpc=self.k_Mpc[0] ## Discard other k bins, they are the same
 
         return
         


### PR DESCRIPTION
fixing #90 - the previous comment correctly states that not all bins are the same due to numerical issues, however these are only different at very high k. I have checked that for all values of k we emulate, the k bins are either numerically the same or have negligible differences.