### PR TITLE
modified post-processing code to be able to choose axis

### DIFF
--- a/post_process/py/snapshot_admin.py
+++ b/post_process/py/snapshot_admin.py
@@ -34,20 +34,20 @@ class SnapshotAdmin(object):
             self.scales_tau=[1.0]
 
 
-    def get_all_flux_power(self,simdir=None):
+    def get_all_flux_power(self,simdir=None,skewers_dir=None):
         """Loop over all skewers, and return flux power for each"""
 
-        if simdir is not None:
-            # get box size from GenIC file, to normalize power
-            if 'simdir' in self.data:
-                simdir = self.data['simdir']
-            elif 'basedir' in self.data:
-                simdir = self.data['basedir']
+        if simdir is None:
+            simdir = self.data['simdir']
 
+        if skewers_dir is None:
+            skewers_dir=self.data['skewers_dir']
+
+        # get box size from GenIC file, to normalize power
         genic_file=simdir+'/paramfile.genic'
         L_Mpc=read_genic.L_Mpc_from_paramfile(genic_file,verbose=True)
 
-        skewers_dir=simdir+"output/skewers/"
+        # get snapshot number from JSON data
         snap_num=self.data['snap_num']
 
         # will loop over all temperature models in snapshot
@@ -96,6 +96,10 @@ class SnapshotAdmin(object):
         
         filename=p1d_label+'_'+str(num)+'_Ns'+str(n_skewers)
         filename+='_wM'+str(int(1000*width_Mpc)/1000)
+
+        if 'axis' in self.data:
+            filename+='_axis'+str(self.data['axis'])
+
         filename+='.json'
 
         return filename
@@ -107,7 +111,8 @@ class SnapshotAdmin(object):
         if p1d_label is None:
             p1d_label='p1d'
 
-        filename=self.data['simdir']+'/'+self.get_p1d_json_filename(p1d_label)
+        filename=self.data['skewers_dir']+'/'+self.get_p1d_json_filename(p1d_label)
+
         print('will print P1d to file',filename)
 
         # make sure we have already computed P1D

--- a/post_process/scripts/arxiv_flux_power.py
+++ b/post_process/scripts/arxiv_flux_power.py
@@ -14,9 +14,10 @@ import json
 parser = argparse.ArgumentParser()
 parser.add_argument('--simdir', type=str, help='Base simulation directory',required=True)
 parser.add_argument('--snap_num', type=int, help='Snapshop number',required=True)
-parser.add_argument('--skewers_dir', type=str, help='Store skewers in this folder',required=False)
+parser.add_argument('--skewers_dir', type=str, help='Store skewers in this folder',required=True)
 parser.add_argument('--n_skewers', type=int, default=10, help='Number of skewers per side',required=False)
 parser.add_argument('--width_Mpc', type=float, default=0.1, help='Cell width (in Mpc)',required=False)
+parser.add_argument('--axis', type=int, help='Axis to use to extract skewers (1,2,3)', required=False)
 parser.add_argument('--scales_tau', type=str, default='1.0', help='Comma-separated list of optical depth scalings to use.',required=False)
 parser.add_argument('--p1d_label', type=str, default=None, help='String identifying P1D measurement and / or tau scaling.',required=False)
 parser.add_argument('--verbose', action='store_true', help='Print runtime information',required=False)
@@ -25,19 +26,12 @@ args = parser.parse_args()
 verbose=args.verbose
 print('verbose =',verbose)
 
-# main simulation folder 
-simdir=args.simdir
-if args.skewers_dir:
-    skewers_dir=args.skewers_dir
-else:
-    skewers_dir=simdir+'/output/skewers/'
-
 scales_tau=[float(scale) for scale in args.scales_tau.split(',')]
 if verbose:
     print('will scale tau by',scales_tau)
 
 # try to read information about filtering length in simulation
-kF_json=simdir+'/filtering_length.json'
+kF_json=args.simdir+'/filtering_length.json'
 if os.path.isfile(kF_json):
     # read json file with filtering data
     with open(kF_json) as json_data:
@@ -48,9 +42,9 @@ else:
     kF_Mpc=None
 
 # read file containing information of all temperature rescalings in snapshot
-snap_filename=skewers_dir+'/'+extract_skewers.get_snapshot_json_filename(
+snap_filename=args.skewers_dir+'/'+extract_skewers.get_snapshot_json_filename(
                 num=args.snap_num,n_skewers=args.n_skewers,
-                width_Mpc=args.width_Mpc)
+                width_Mpc=args.width_Mpc,axis=args.axis)
 if verbose:
     print('setup snapshot admin from file',snap_filename)
 

--- a/post_process/scripts/extract_default_skewers.py
+++ b/post_process/scripts/extract_default_skewers.py
@@ -11,7 +11,8 @@ import json
 parser = argparse.ArgumentParser()
 parser.add_argument('--simdir', type=str, help='Base simulation directory',required=True)
 parser.add_argument('--skewers_dir', type=str, help='Store skewers in this folder',required=True)
-parser.add_argument('--snap_num', type=int, default=8, help='Snapshot number',required=False)
+parser.add_argument('--snap_num', type=int, help='Snapshot number',required=True)
+parser.add_argument('--axis', type=int, help='Axis to use to extract skewers (1,2,3)',required=False)
 parser.add_argument('--n_skewers', type=int, default=10, help='Number of skewers per side',required=False)
 parser.add_argument('--width_Mpc', type=float, default=0.1, help='Cell width (in Mpc)',required=False)
 parser.add_argument('--verbose', action='store_true', help='Print runtime information',required=False)
@@ -24,7 +25,7 @@ print("----------")
 # extract skewers for one snapshot, and return some info 
 info=extract_skewers.rescale_write_skewers_z(simdir=args.simdir,
             num=args.snap_num, skewers_dir=args.skewers_dir,
-            n_skewers=args.n_skewers,width_Mpc=args.width_Mpc)
+            axis=args.axis,n_skewers=args.n_skewers,width_Mpc=args.width_Mpc)
 
 if args.verbose:
     print('print extra info about skewers')


### PR DESCRIPTION
Adds option to specify the axis along which we want to extract the skewers and measure p1d.

It also includes book-keeping changes in extract_skewers.py and snapshot_admin.py related to issue #98.

When using axis=None, the code reproduces the current p1d (with the book-keeping changes mentioned above).

Before merging this, we should wait for GriddedSpectra in fake_spectra to be updated: https://github.com/sbird/fake_spectra/issues/42